### PR TITLE
Fix update error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 /vendor
 composer.phar
 composer.lock
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 composer.phar
 composer.lock
 .DS_Store
-.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 matrix:
   include:

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "keycloak"
     ],
     "require": {
-        "league/oauth2-client": "^2.0 <2.3.0",
+        "league/oauth2-client": "^2.0",
         "firebase/php-jwt": "^4.0"
     },
     "require-dev": {

--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -10,6 +10,7 @@ use League\OAuth2\Client\Token\AccessToken;
 use League\OAuth2\Client\Tool\BearerAuthorizationTrait;
 use Psr\Http\Message\ResponseInterface;
 use Stevenmaguire\OAuth2\Client\Provider\Exception\EncryptionConfigurationException;
+use UnexpectedValueException;
 
 class Keycloak extends AbstractProvider
 {
@@ -210,10 +211,17 @@ class Keycloak extends AbstractProvider
      *
      * @param  AccessToken $token
      * @return KeycloakResourceOwner
+     * @throws EncryptionConfigurationException
      */
     public function getResourceOwner(AccessToken $token)
     {
         $response = $this->fetchResourceOwnerDetails($token);
+
+        // We are always getting an array. We have to check if it is
+        // the array we created
+        if (array_key_exists('jwt', $response)) {
+            $response = $response['jwt'];
+        }
 
         $response = $this->decryptResponse($response);
 
@@ -275,5 +283,31 @@ class Keycloak extends AbstractProvider
     public function usesEncryption()
     {
         return (bool) $this->encryptionAlgorithm && $this->encryptionKey;
+    }
+
+    /**
+     * Parses the response according to its content-type header.
+     *
+     * @throws UnexpectedValueException
+     * @param  ResponseInterface $response
+     * @return array
+     */
+    protected function parseResponse(ResponseInterface $response)
+    {
+        // We have a problem with keycloak when the userinfo responses
+        // with a jwt token
+        // Because it just return a jwt as string with the header
+        // application/jwt
+        // This can't be parsed to a array
+        // Dont know why this function only allow an array as return value...
+        $content = (string) $response->getBody();
+        $type = $this->getContentType($response);
+
+        if (strpos($type, 'jwt') !== false) {
+            // Here we make the temporary array
+            return ['jwt' => $content];
+        }
+
+        return parent::parseResponse($response);
     }
 }


### PR DESCRIPTION
This pull request solves #15 .

The problem was `parseResponse` function from AbstractProvider which force the reponse to be an array and have no possibility to parse `application/jwt`.
If we use encrypted userinfo endpoint we are getting only the jwt token which is a simple string.

This results in an `UnexpectedValueException` with the message _An OAuth server error was encountered that did not contain a JSON body_. Also see `AbstractProvider` line 694.
