### PR TITLE
Change default scope separator to space

### DIFF
--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -178,6 +178,18 @@ class Keycloak extends AbstractProvider
     }
 
     /**
+     * Returns the string that should be used to separate scopes when building
+     * the URL for requesting an access token.
+     *
+     * @return string Scope separator, defaults to ','
+     */
+    protected function getScopeSeparator()
+    {
+        return ' ';
+    }
+
+
+    /**
      * Check a provider response for errors.
      *
      * @throws IdentityProviderException


### PR DESCRIPTION
I'm not sure about this PR but I'm facing an issue it seems nobody else have.

Currently, the auth call is `https://<keycloak url>/auth/realms/<realm>/protocol/openid-connect/auth?scope=email%2Copenid%2Cprofile%2Coffline_access%2Cphone&state=<state>&response_type=code&approval_prompt=auto&redirect_uri=<url encoded redirect uri>&client_id=<client>` because [the scope separator is the comma](https://github.com/thephpleague/oauth2-client/blob/0facae9209aef5643bdd780e99996a21b6769c36/src/Provider/AbstractProvider.php#L324) and the urlencode is [PHP_QUERY_RFC3986](https://github.com/thephpleague/oauth2-client/blob/0facae9209aef5643bdd780e99996a21b6769c36/src/Tool/QueryBuilderTrait.php#L29). 

This results by Keycloak not following the scope given and only returning the default one (email and profile in my case). So I get a `Refresh` refresh token and not an `Offline` as asked. 

Changing the scope separator to be a space fix it for me.

I don't think it's relevant but I've some layers of AWS cloudfront / ALB before getting to Keycloak.