### PR TITLE
Fix errors without a description

### DIFF
--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -200,7 +200,10 @@ class Keycloak extends AbstractProvider
     protected function checkResponse(ResponseInterface $response, $data)
     {
         if (!empty($data['error'])) {
-            $error = $data['error'].': '.$data['error_description'];
+            $error = $data['error'];
+            if(isset($data['error_description'])){
+                $error.=': '.$data['error_description'];
+            }
             throw new IdentityProviderException($error, 0, $data);
         }
     }


### PR DESCRIPTION
Some errors are missing the description causing inconsistent behaviours.
Simplest failing error check is "Realm does not exist".
If the realm does not exist there is no "error_description" set.

Keycloak 11.0.3