### PR TITLE
Add a status code to the IdentityProviderException

### DIFF
--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -201,7 +201,7 @@ class Keycloak extends AbstractProvider
     {
         if (!empty($data['error'])) {
             $error = $data['error'].': '.$data['error_description'];
-            throw new IdentityProviderException($error, 0, $data);
+            throw new IdentityProviderException($error, $response->getStatusCode(), $data);
         }
     }
 

--- a/test/src/Provider/KeycloakTest.php
+++ b/test/src/Provider/KeycloakTest.php
@@ -295,6 +295,7 @@ namespace Stevenmaguire\OAuth2\Client\Test\Provider
             $response = m::mock('Psr\Http\Message\ResponseInterface');
             $response->shouldReceive('getBody')->andReturn('{"error": "invalid_grant", "error_description": "Code not found"}');
             $response->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+            $response->shouldReceive('getStatusCode')->andReturn(401);
 
             $client = m::mock('GuzzleHttp\ClientInterface');
             $client->shouldReceive('send')->times(1)->andReturn($response);


### PR DESCRIPTION
Previously this exception would always have `0` as the status code, making it impossible to know what was the status of the response that caused that exception.