### PR TITLE
add a getPreferredUsername in Stevenmaguire\OAuth2\Client\Provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "keycloak"
     ],
     "require": {
-        "league/oauth2-client": "^2.0 <2.3.0",
+        "league/oauth2-client": "^2.0",
         "firebase/php-jwt": "^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
Can you add this in your Stevenmaguire\OAuth2\Client\Provider file? it's for get the keycloak preferred_username

`/**
     * Get resource owner preferred_username
     *
     * @return string|null
     */
    public function getPreferredUsername()
    {
        return $this->response['preferred_username'] ?: null;
    }`