### PR TITLE
Fix Warning: Undefined array key on PHP8

### DIFF
--- a/src/Provider/KeycloakResourceOwner.php
+++ b/src/Provider/KeycloakResourceOwner.php
@@ -30,7 +30,7 @@ class KeycloakResourceOwner implements ResourceOwnerInterface
      */
     public function getId()
     {
-        return $this->response['sub'] ?: null;
+        return $this->response['sub'] ?? null;
     }
 
     /**
@@ -40,7 +40,7 @@ class KeycloakResourceOwner implements ResourceOwnerInterface
      */
     public function getEmail()
     {
-        return $this->response['email'] ?: null;
+        return $this->response['email'] ?? null;
     }
 
     /**
@@ -50,7 +50,7 @@ class KeycloakResourceOwner implements ResourceOwnerInterface
      */
     public function getName()
     {
-        return $this->response['name'] ?: null;
+        return $this->response['name'] ?? null;
     }
 
     /**

--- a/src/Provider/KeycloakResourceOwner.php
+++ b/src/Provider/KeycloakResourceOwner.php
@@ -30,7 +30,7 @@ class KeycloakResourceOwner implements ResourceOwnerInterface
      */
     public function getId()
     {
-        return $this->response['sub'] ?? null;
+        return \array_key_exists('sub', $this->response) ? $this->response['sub'] : null;
     }
 
     /**
@@ -40,7 +40,7 @@ class KeycloakResourceOwner implements ResourceOwnerInterface
      */
     public function getEmail()
     {
-        return $this->response['email'] ?? null;
+        return \array_key_exists('email', $this->response) ? $this->response['email'] : null;
     }
 
     /**
@@ -50,7 +50,7 @@ class KeycloakResourceOwner implements ResourceOwnerInterface
      */
     public function getName()
     {
-        return $this->response['name'] ?? null;
+        return \array_key_exists('name', $this->response) ? $this->response['name'] : null;
     }
 
     /**


### PR DESCRIPTION
Hello,

With PHP8.1 and Symfony 6.0 I've got an error when I tried to call `getName` method.

```php
/** @var KeycloakResourceOwner $keycloakUser */
$keycloakUser = $client->fetchUserFromToken($accessToken);

$keycloakUser->getName(); // Warning: Undefined array key "name"
```

Have a nice day.