### PR TITLE
Adjust unit test to changed scope seperator

### DIFF
--- a/test/src/Provider/KeycloakTest.php
+++ b/test/src/Provider/KeycloakTest.php
@@ -132,7 +132,7 @@ namespace Stevenmaguire\OAuth2\Client\Test\Provider
 
         public function testScopes()
         {
-            $scopeSeparator = ',';
+            $scopeSeparator = ' ';
             $options = ['scope' => [uniqid(), uniqid()]];
             $query = ['scope' => implode($scopeSeparator, $options['scope'])];
             $url = $this->provider->getAuthorizationUrl($options);


### PR DESCRIPTION
Since https://github.com/stevenmaguire/oauth2-keycloak/pull/23 the scope separator is ` ` and not `,` anymore.