### PR TITLE
Allow league/oauth2-client ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "keycloak"
     ],
     "require": {
-        "league/oauth2-client": "^2.0 <2.3.0",
+        "league/oauth2-client": "^2.0",
         "firebase/php-jwt": "~4.0|~5.0"
     },
     "require-dev": {

--- a/test/src/Provider/KeycloakTest.php
+++ b/test/src/Provider/KeycloakTest.php
@@ -132,7 +132,7 @@ namespace Stevenmaguire\OAuth2\Client\Test\Provider
 
         public function testScopes()
         {
-            $scopeSeparator = ',';
+            $scopeSeparator = ' ';
             $options = ['scope' => [uniqid(), uniqid()]];
             $query = ['scope' => implode($scopeSeparator, $options['scope'])];
             $url = $this->provider->getAuthorizationUrl($options);


### PR DESCRIPTION
I've removed the constraint for league/oauth2-client. This will allow to use the latest version of [Guzzle](https://packagist.org/packages/guzzlehttp/guzzle)

In #26 @mstefan21 you mention that the files are fixed for 7.3 and therefor you didn't allow this change.

Is this still true?