### PR TITLE
Add a status code to the IdentityProviderException

### DIFF
--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -243,7 +243,7 @@ class Keycloak extends AbstractProvider
             if (isset($data['error_description'])) {
                 $error .= ': '.$data['error_description'];
             }
-            throw new IdentityProviderException($error, 0, $data);
+            throw new IdentityProviderException($error, $response->getStatusCode(), $data);
         }
     }
 

--- a/test/src/Provider/KeycloakTest.php
+++ b/test/src/Provider/KeycloakTest.php
@@ -512,7 +512,9 @@ EOF;
                 ->andReturn($accessTokenResponseStream);
             $response
                 ->shouldReceive('getHeader')
-                ->andReturn(['content-type' => 'json']);
+            $response
+                ->shouldReceive('getStatusCode')
+                ->andReturn(401);
 
             $client = m::mock('GuzzleHttp\ClientInterface');
             $client


### PR DESCRIPTION
Previously this exception would always have `0` as the status code,
making it impossible to know what was the status of the response that
caused that exception.