### PR TITLE
Fix default scopes for KC20

### DIFF
--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -175,7 +175,7 @@ class Keycloak extends AbstractProvider
      */
     protected function getDefaultScopes()
     {
-        return ['profile', 'email'];
+        return ['profile', 'email', 'openid'];
     }
 
     /**

--- a/src/Provider/Keycloak.php
+++ b/src/Provider/Keycloak.php
@@ -202,7 +202,7 @@ class Keycloak extends AbstractProvider
     {
         if (!empty($data['error'])) {
             $error = $data['error'];
-            if(isset($data['error_description'])){
+            if (isset($data['error_description'])) {
                 $error.=': '.$data['error_description'];
             }
             throw new IdentityProviderException($error, 0, $data);


### PR DESCRIPTION
Based on issue #55, added the required scope openid to the default list.