### PR TITLE
Upgrade to PHPUnit 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,12 @@ language: php
 sudo: false
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
+  - 8.1
+  - 8.2
 
 matrix:
   include:

--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,11 @@
         "branch-alias": {
             "dev-master": "1.0.x-dev"
         }
+    },
+    "scripts": {
+        "test": [
+            "@putenv XDEBUG_MODE=coverage",
+            "phpunit --colors=always"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         "keycloak"
     ],
     "require": {
-        "php": "~7.2|~8.0",
+        "php": "~7.2 || ~8.0",
         "league/oauth2-client": "^2.0",
-        "firebase/php-jwt": "~4.0|~5.0|~6.0"
+        "firebase/php-jwt": "^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~9.6.4",

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,14 @@
         "keycloak"
     ],
     "require": {
+        "php": "~7.2|~8.0",
         "league/oauth2-client": "^2.0",
-        "firebase/php-jwt": "~4.0|~5.0"
+        "firebase/php-jwt": "~4.0|~5.0|~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.0",
-        "mockery/mockery": "~0.9",
-        "squizlabs/php_codesniffer": "~2.0"
+        "phpunit/phpunit": "~9.6.4",
+        "mockery/mockery": "~1.5.0",
+        "squizlabs/php_codesniffer": "~3.7.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,38 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit backupGlobals="false"
-         backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
+         failOnRisky="true"
+         failOnWarning="true"
 >
-    <logging>
-        <log type="coverage-html"
-                target="./build/coverage/html"
-                charset="UTF-8"
-                highlight="false"
-                lowUpperBound="35"
-                highLowerBound="70"/>
-          <log type="coverage-clover"
-                target="./build/coverage/log/coverage.xml"/>
-    </logging>
+    <coverage includeUncoveredFiles="true"
+              pathCoverage="false"
+              ignoreDeprecatedCodeUnits="true"
+              disableCodeCoverageIgnore="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">vendor</directory>
+            <file>src/autoload.php</file>
+        </exclude>
+        <report>
+            <html outputDirectory="./build/coverage/html"
+                  lowUpperBound="35"
+                  highLowerBound="70"/>
+            <clover outputFile="./build/coverage/log/coverage.xml"/>
+        </report>
+    </coverage>
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix=".php">./test/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./</directory>
-            <exclude>
-                <directory suffix=".php">./examples</directory>
-                <directory suffix=".php">./vendor</directory>
-                <directory suffix=".php">./test</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+    <php>
+        <ini name="xdebug.mode" value="coverage"/>
+    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -30,7 +30,4 @@
             <directory suffix=".php">./test/</directory>
         </testsuite>
     </testsuites>
-    <php>
-        <ini name="xdebug.mode" value="coverage"/>
-    </php>
 </phpunit>

--- a/test/src/Provider/KeycloakTest.php
+++ b/test/src/Provider/KeycloakTest.php
@@ -25,14 +25,15 @@ namespace Stevenmaguire\OAuth2\Client\Test\Provider
 {
     use League\OAuth2\Client\Tool\QueryBuilderTrait;
     use Mockery as m;
+    use PHPUnit\Framework\TestCase;
 
-    class KeycloakTest extends \PHPUnit_Framework_TestCase
+    class KeycloakTest extends TestCase
     {
         use QueryBuilderTrait;
 
         protected $provider;
 
-        protected function setUp()
+        protected function setUp(): void
         {
             $this->provider = new \Stevenmaguire\OAuth2\Client\Provider\Keycloak([
                 'authServerUrl' => 'http://mock.url/auth',
@@ -43,7 +44,7 @@ namespace Stevenmaguire\OAuth2\Client\Test\Provider
             ]);
         }
 
-        public function tearDown()
+        public function tearDown(): void
         {
             m::close();
             parent::tearDown();
@@ -137,7 +138,7 @@ namespace Stevenmaguire\OAuth2\Client\Test\Provider
             $query = ['scope' => implode($scopeSeparator, $options['scope'])];
             $url = $this->provider->getAuthorizationUrl($options);
             $encodedScope = $this->buildQueryString($query);
-            $this->assertContains($encodedScope, $url);
+            $this->assertStringContainsString($encodedScope, $url);
         }
 
         public function testGetAuthorizationUrl()
@@ -262,11 +263,10 @@ namespace Stevenmaguire\OAuth2\Client\Test\Provider
             $this->assertEquals($email, $user->toArray()['email']);
         }
 
-        /**
-         * @expectedException Stevenmaguire\OAuth2\Client\Provider\Exception\EncryptionConfigurationException
-         */
         public function testUserDataFailsWhenEncryptionEncounteredAndNotConfigured()
         {
+            $this->expectException(EncryptionConfigurationException::class);
+
             $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
             $postResponse->shouldReceive('getBody')->andReturn('access_token=mock_access_token&expires=3600&refresh_token=mock_refresh_token&otherKey={1234}');
             $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'application/x-www-form-urlencoded']);
@@ -287,11 +287,10 @@ namespace Stevenmaguire\OAuth2\Client\Test\Provider
             $user = $this->provider->getResourceOwner($token);
         }
 
-        /**
-         * @expectedException League\OAuth2\Client\Provider\Exception\IdentityProviderException
-         */
         public function testErrorResponse()
         {
+            $this->expectException(IdentityProviderException::class);
+
             $response = m::mock('Psr\Http\Message\ResponseInterface');
             $response->shouldReceive('getBody')->andReturn('{"error": "invalid_grant", "error_description": "Code not found"}');
             $response->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);


### PR DESCRIPTION
This PR upgrades PHPUnit to version 9. The main motivation for this is so that the package can make use of _most_ of the latest PHPUnit functionality and not fall too far behind the development curve. The change also upgrades the two other development dependencies to the latest versions respectively, for good measure.

I had originally intended to upgrade the package to PHPUnit 10, but that has a minimum PHP version of 8.1, which might be too far of an upgrade if this package wants broad PHP support.

For complete transparency, this PR was also motivated by this package being a dependency of a library that I wrote. I can't upgrade that package without this one being upgraded.