### PR TITLE
Use the preferred_username claim to get the resource owner name

### DIFF
--- a/src/Provider/KeycloakResourceOwner.php
+++ b/src/Provider/KeycloakResourceOwner.php
@@ -50,7 +50,7 @@ class KeycloakResourceOwner implements ResourceOwnerInterface
      */
     public function getName()
     {
-        return \array_key_exists('name', $this->response) ? $this->response['name'] : null;
+        return \array_key_exists('preferred_username', $this->response) ? $this->response['preferred_username'] : null;
     }
 
     /**


### PR DESCRIPTION
Since the [OpenID](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) specification defines this as part of the standard claims and software, like Keycloak, uses the `preferred_username` claim to hold an account's username.