### PR TITLE
Fix invalid syntax in test file

### DIFF
--- a/test/src/Provider/KeycloakTest.php
+++ b/test/src/Provider/KeycloakTest.php
@@ -512,6 +512,7 @@ EOF;
                 ->andReturn($accessTokenResponseStream);
             $response
                 ->shouldReceive('getHeader')
+                ->andReturn(['content-type' => 'json']);
             $response
                 ->shouldReceive('getStatusCode')
                 ->andReturn(401);


### PR DESCRIPTION
This line was accidentally erased in 1b690b7377dfe7a23e1590373f37e12cf40a6d75.